### PR TITLE
Fix `Uncaught _H: "initData" transformer failed to parse the value`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "reactjs-template",
       "version": "0.0.1",
       "dependencies": {
-        "@telegram-apps/sdk-react": "^2.0.10",
-        "@telegram-apps/telegram-ui": "^2.1.5",
+        "@telegram-apps/sdk-react": "^2.0.20",
+        "@telegram-apps/telegram-ui": "^2.1.8",
         "@tonconnect/ui-react": "^2.0.5",
         "eruda": "^3.0.1",
         "react": "^18.2.0",
@@ -1559,47 +1559,52 @@
       }
     },
     "node_modules/@telegram-apps/bridge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/bridge/-/bridge-1.4.0.tgz",
-      "integrity": "sha512-75FHIYtIg2/c7F1Y1YX8IT4XWTGu8G4Dm0lopIeQIsyIc3hjHtGwcNt5GQ69UFJXIJlYrv6lu+qUC+K4sbgRZw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/bridge/-/bridge-1.7.1.tgz",
+      "integrity": "sha512-oRbznpIC4UibMVygQ+tcS0ZSKx7DaI07MXQF42VETQ/VOCKeaWZeQFUifo4A+CzT6XMGo2hyse/CQP9ziX0H7g==",
+      "license": "MIT",
       "dependencies": {
         "@telegram-apps/signals": "^1.1.0",
         "@telegram-apps/toolkit": "^1.0.0",
-        "@telegram-apps/transformers": "^1.0.1",
-        "@telegram-apps/types": "^1.0.1"
+        "@telegram-apps/transformers": "^1.2.0",
+        "@telegram-apps/types": "^1.2.0"
       }
     },
     "node_modules/@telegram-apps/navigation": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/navigation/-/navigation-1.0.5.tgz",
-      "integrity": "sha512-fGOzfFKPe8PUfbtSRlWx/V9xUeLK3hlA5w+2X3by8B4fpwCBPEy+iCrtAKUJNH9qM5i2c3YteQIM56sD3yyXpQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/navigation/-/navigation-1.0.9.tgz",
+      "integrity": "sha512-Ur24luu+fizrKCDQAoJWQzMj+IwNiqtQlrITz42DORKSohj5yvf9kD5AJO2r9sHC+iC2pLXHCn1dV34o6tbeaQ==",
+      "license": "MIT",
       "dependencies": {
-        "@telegram-apps/bridge": "^1.4.0",
+        "@telegram-apps/bridge": "^1.7.1",
         "@telegram-apps/signals": "^1.1.0",
         "@telegram-apps/toolkit": "^1.0.0"
       }
     },
     "node_modules/@telegram-apps/sdk": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-2.6.0.tgz",
-      "integrity": "sha512-UVu7y1XDIACwL5okygD20ILnnEYpXXllWX6BFVAVlXXcb4afUEnR+MLCaOnTBWzCHEF3HIaRs1kpgwXmWJ3fLA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-2.9.1.tgz",
+      "integrity": "sha512-fW5e0B7yt4jIlEJfXzZwrY2cYufyXQw6xIu2eRfKl1l6N/ETIwZZRr6jOOsRCzzpWUfqePvwItqKIuRf8mGcog==",
+      "license": "MIT",
       "dependencies": {
-        "@telegram-apps/bridge": "^1.4.0",
-        "@telegram-apps/navigation": "^1.0.5",
+        "@telegram-apps/bridge": "^1.7.1",
+        "@telegram-apps/navigation": "^1.0.9",
         "@telegram-apps/signals": "^1.1.0",
-        "@telegram-apps/transformers": "^1.0.1"
+        "@telegram-apps/toolkit": "^1.0.0",
+        "@telegram-apps/transformers": "^1.2.0"
       }
     },
     "node_modules/@telegram-apps/sdk-react": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk-react/-/sdk-react-2.0.10.tgz",
-      "integrity": "sha512-eo0r4dnGhRAerwiIXp2+viiUeP1qtAveI0qmWnKOmC7KHINzLDncfxYTFQ5ysUn/0iUuxTBwOGe5rVd2jpxZaA==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk-react/-/sdk-react-2.0.20.tgz",
+      "integrity": "sha512-kLVFeT+cpLSjRgvrYU/8IDId4WmZzwvvW0uoEGk1dVFoRvZCmopelF+Jjgk9m6ybGq4S5B8YQMWglimE09dRhw==",
+      "license": "MIT",
       "dependencies": {
-        "@telegram-apps/sdk": "^2.6.0"
+        "@telegram-apps/sdk": "^2.9.1"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -1610,12 +1615,14 @@
     "node_modules/@telegram-apps/signals": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@telegram-apps/signals/-/signals-1.1.0.tgz",
-      "integrity": "sha512-5qN7cU8t3l7n0cKcnzc/1TYKJTwAggUinfwbLHL1SYmB47pBHjCvfsRiYliFohk6lb635SBmNuVZL6LHFmGZaw=="
+      "integrity": "sha512-5qN7cU8t3l7n0cKcnzc/1TYKJTwAggUinfwbLHL1SYmB47pBHjCvfsRiYliFohk6lb635SBmNuVZL6LHFmGZaw==",
+      "license": "MIT"
     },
     "node_modules/@telegram-apps/telegram-ui": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/telegram-ui/-/telegram-ui-2.1.5.tgz",
-      "integrity": "sha512-6gwGjmJXJDCx2dwFe7q+iie+R9QB+KD7JKXEID8dhA83pw4rkHJXrmq9rQq14CgIu0MtRVaHb2ryj+PE1imYDQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/telegram-ui/-/telegram-ui-2.1.8.tgz",
+      "integrity": "sha512-Y4mIRzBJDerFvF6yzsfwHpu2tKEMHnnnQgdnLTwIdXNVPq/sJTaY66Qxbh9eeO5+tct01VcAx4E70/1fMvnp8A==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.8",
         "@swc/helpers": "^0.5.3",
@@ -1634,21 +1641,24 @@
     "node_modules/@telegram-apps/toolkit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@telegram-apps/toolkit/-/toolkit-1.0.0.tgz",
-      "integrity": "sha512-fSVoveLuMzwRKWeXEufMSXxH+HvjsFKb1DeT3pG5qLpnb2rdtejnNcwAt6WEPtiZ3a4YntYaFuR3KYgVv0ZxeQ=="
+      "integrity": "sha512-fSVoveLuMzwRKWeXEufMSXxH+HvjsFKb1DeT3pG5qLpnb2rdtejnNcwAt6WEPtiZ3a4YntYaFuR3KYgVv0ZxeQ==",
+      "license": "MIT"
     },
     "node_modules/@telegram-apps/transformers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/transformers/-/transformers-1.0.1.tgz",
-      "integrity": "sha512-SsI+FhCOkkZFUPqr+ib11Fi25fRCpdMsI2Flp51NrdtKaPDnKFkBBG4GcSEaGL8sXquW9uAANjc499jSaZK5jQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/transformers/-/transformers-1.2.0.tgz",
+      "integrity": "sha512-RufLdD044RPaAJdh+Mp/98JI+Wkp5mhX3WYCg6IZYFMRwu3QTu2FBwYmU9FdRmBF9utbcymSFrY1cqxh+Vtkfg==",
+      "license": "MIT",
       "dependencies": {
         "@telegram-apps/toolkit": "^1.0.0",
-        "@telegram-apps/types": "^1.0.1"
+        "@telegram-apps/types": "^1.2.0"
       }
     },
     "node_modules/@telegram-apps/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-8tGy1zG/1MEt0KF8nR0ffZ93whKveEJIkBI+qxHCRgatKwKVJV2dVSXrrBspFKn7FIIo1/CvmB8zP4vKPzglbg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-HhvnSCsqlJpes5ZGsZP/qbDNq8eLLnjgZKaF5NRsDqAKUPvaIIFT1HdyDII/8EioUgoI4FHsP8MylK2Gzm2efg==",
+      "license": "MIT"
     },
     "node_modules/@tonconnect/isomorphic-eventsource": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "predeploy": "npm run build"
   },
   "dependencies": {
-    "@telegram-apps/sdk-react": "^2.0.10",
-    "@telegram-apps/telegram-ui": "^2.1.5",
+    "@telegram-apps/sdk-react": "^2.0.20",
+    "@telegram-apps/telegram-ui": "^2.1.8",
     "@tonconnect/ui-react": "^2.0.5",
     "eruda": "^3.0.1",
     "react": "^18.2.0",

--- a/src/mockEnv.ts
+++ b/src/mockEnv.ts
@@ -37,6 +37,7 @@ if (import.meta.env.DEV) {
         ['start_param', 'debug'],
         ['chat_type', 'sender'],
         ['chat_instance', '8428209589180549439'],
+        ['signature', '6fbdaab833d39f54518bd5c3eb3f511d035e68cb'],
       ]).toString();
 
       lp = {


### PR DESCRIPTION
Background: @heyqbnk Add signature parser in this commit: https://github.com/Telegram-Mini-Apps/telegram-apps/commit/3473f7038ebd0274b90357065b329262f1732840.

So after that when user upgrade Telegram-SDK to the latest version, they can't successfully open page that use mock env.

They will get this error:

![image](https://github.com/user-attachments/assets/e6127b83-3c71-4ab8-87b9-687eae6f971b)


